### PR TITLE
Fix handling of update commit response

### DIFF
--- a/src/components/UpdateForm/UpdateForm.jsx
+++ b/src/components/UpdateForm/UpdateForm.jsx
@@ -76,7 +76,8 @@ class UpdateForm extends PureComponent {
     batch
       .set(entryRef, entryPayload, {merge: true})
       .set(privateRef, privatePayload, {merge: true})
-      .commit(() => {
+      .commit()
+      .then(() => {
         this.setState({
           changedFields: {}
         });


### PR DESCRIPTION
The callback function of the commit() was not being called.
Including it in a then() function instead fixes the issue